### PR TITLE
Fix usage of wrong Position interface.

### DIFF
--- a/lib/source-map-generator.d.ts
+++ b/lib/source-map-generator.d.ts
@@ -1,4 +1,4 @@
-import { StartOfSourceMap, SourceMapConsumer } from './source-map-consumer'
+import { StartOfSourceMap, SourceMapConsumer, Position } from './source-map-consumer'
 
 export interface Mapping {
   generated: Position;


### PR DESCRIPTION
We need to also import the Position interface from source-map-consumer, because otherwise it will use the one globally provided by lib.d.ts. Therefore the addMapping function cannot be used correctly.